### PR TITLE
PDFDemos fixes and improvements

### DIFF
--- a/src/Artefact-Examples/PDFClockElement.class.st
+++ b/src/Artefact-Examples/PDFClockElement.class.st
@@ -22,7 +22,10 @@ PDFClockElement class >> clockTutorialStep1 [
 	"I will generate a PDF with the clock step example"
 
 	<script>
-	(PDFDocument element: (PDFPage element: ((self from: 2 cm @ 2 cm to: 10 cm @ 10 cm) time: Time current))) exportTo: (self streamNamed: 'clockTutorialStep1.pdf')
+	self streamNamed: 'clockTutorialStep1.pdf' do: [ :s |
+		(PDFDocument element: (PDFPage element:
+				  ((self from: 2 cm @ 2 cm to: 10 cm @ 10 cm) time: Time current)))
+			exportTo: s ]
 ]
 
 { #category : #steps }
@@ -30,12 +33,15 @@ PDFClockElement class >> clockTutorialStep2 [
 	"I will generate a PDF with the clock step example"
 
 	<script>
-	| doc |
-	doc := PDFDocument element: (PDFPage element: ((self from: 2 cm @ 2 cm to: 10 cm @ 10 cm) time: Time current)).
-	(doc styleSheet > #clock)
-		drawColor: (PDFColor r: 180 g: 24 b: 24);
-		fillColor: (PDFColor r: 230 g: 230 b: 10).
-	doc exportTo: (self streamNamed: 'clockTutorialStep2.pdf')
+	self streamNamed: 'clockTutorialStep2.pdf' do: [ :s |
+		| doc |
+		doc := PDFDocument element: (PDFPage element:
+				        ((self from: 2 cm @ 2 cm to: 10 cm @ 10 cm) time:
+					         Time current)).
+		(doc styleSheet > #clock)
+			drawColor: (PDFColor r: 180 g: 24 b: 24);
+			fillColor: (PDFColor r: 230 g: 230 b: 10).
+		doc exportTo: s ]
 ]
 
 { #category : #steps }
@@ -43,13 +49,17 @@ PDFClockElement class >> clockTutorialStep3 [
 	"I will generate a PDF with the clock step example"
 
 	<script>
-	| doc |
-	doc := PDFDocument element: (PDFPage element: ((self from: 2 cm @ 2 cm to: 10 cm @ 10 cm) time: Time current)).
-	(doc styleSheet > #clock)
-		drawColor: (PDFColor r: 180 g: 24 b: 24);
-		fillColor: (PDFColor r: 230 g: 230 b: 10).
-	doc styleSheet > #clock > #arrow drawColor: (PDFColor r: 0 g: 45 b: 200).
-	doc exportTo: (self streamNamed: 'clockTutorialStep3.pdf')
+	self streamNamed: 'clockTutorialStep3.pdf' do: [ :s |
+		| doc |
+		doc := PDFDocument element: (PDFPage element:
+				        ((self from: 2 cm @ 2 cm to: 10 cm @ 10 cm) time:
+					         Time current)).
+		(doc styleSheet > #clock)
+			drawColor: (PDFColor r: 180 g: 24 b: 24);
+			fillColor: (PDFColor r: 230 g: 230 b: 10).
+		doc styleSheet > #clock > #arrow drawColor:
+			(PDFColor r: 0 g: 45 b: 200).
+		doc exportTo: s ]
 ]
 
 { #category : #steps }
@@ -57,14 +67,19 @@ PDFClockElement class >> clockTutorialStep4 [
 	"I will generate a PDF with the clock step example"
 
 	<script>
-	| doc |
-	doc := PDFDocument element: (PDFPage element: ((self from: 2 cm @ 2 cm to: 10 cm @ 10 cm) time: Time current)).
-	(doc styleSheet > #clock)
-		drawColor: (PDFColor r: 180 g: 24 b: 24);
-		fillColor: (PDFColor r: 230 g: 230 b: 10).
-	doc styleSheet > #clock > #hourHand drawColor: (PDFColor r: 0 g: 45 b: 200).
-	doc styleSheet > #clock > #minuteHand drawColor: (PDFColor r: 0 g: 200 b: 45).
-	doc exportTo: (self streamNamed: 'clockTutorialStep4.pdf')
+	self streamNamed: 'clockTutorialStep4.pdf' do: [ :s |
+		| doc |
+		doc := PDFDocument element: (PDFPage element:
+				        ((self from: 2 cm @ 2 cm to: 10 cm @ 10 cm) time:
+					         Time current)).
+		(doc styleSheet > #clock)
+			drawColor: (PDFColor r: 180 g: 24 b: 24);
+			fillColor: (PDFColor r: 230 g: 230 b: 10).
+		doc styleSheet > #clock > #hourHand drawColor:
+			(PDFColor r: 0 g: 45 b: 200).
+		doc styleSheet > #clock > #minuteHand drawColor:
+			(PDFColor r: 0 g: 200 b: 45).
+		doc exportTo: s ]
 ]
 
 { #category : #steps }
@@ -72,45 +87,37 @@ PDFClockElement class >> clockTutorialStep5 [
 	"I will generate a PDF with the clock step example"
 
 	<script>
-	| doc |
-	doc := PDFDocument
-		element:
-			(PDFPage
-				elements:
-					{((self from: 2 cm @ 2 cm to: 10 cm @ 10 cm)
-						time: Time current;
-						yourself) . ((self from: 12 cm @ 2 cm to: 20 cm @ 10 cm)
-						time: Time current;
-						style: #apocalypseClock;
-						yourself)}).
-	(doc styleSheet > #clock)
-		drawColor: (PDFColor r: 180 g: 24 b: 24);
-		fillColor: (PDFColor r: 230 g: 230 b: 10).
-	doc styleSheet > #clock > #hourHand drawColor: (PDFColor r: 0 g: 45 b: 200).
-	doc styleSheet > #clock > #minuteHand drawColor: (PDFColor r: 0 g: 200 b: 45).
-	(doc styleSheet > #apocalypseClock)
-		fillColor: (PDFColor r: 244 g: 221 b: 25);
-		thickness: 2 mm;
-		roundCap: true.
-	(doc styleSheet > #apocalypseClock > #minuteHand)
-		drawColor: (PDFColor r: 240 g: 6 b: 7);
-		thickness: 1 mm.
-	doc exportTo: (self streamNamed: 'clockTutorialStep5.pdf')
+	self streamNamed: 'clockTutorialStep5.pdf' do: [ :s |
+		| doc |
+		doc := PDFDocument element: (PDFPage elements: {
+					        ((self from: 2 cm @ 2 cm to: 10 cm @ 10 cm)
+						         time: Time current;
+						         yourself).
+					        ((self from: 12 cm @ 2 cm to: 20 cm @ 10 cm)
+						         time: Time current;
+						         style: #apocalypseClock;
+						         yourself) }).
+		(doc styleSheet > #clock)
+			drawColor: (PDFColor r: 180 g: 24 b: 24);
+			fillColor: (PDFColor r: 230 g: 230 b: 10).
+		doc styleSheet > #clock > #hourHand drawColor:
+			(PDFColor r: 0 g: 45 b: 200).
+		doc styleSheet > #clock > #minuteHand drawColor:
+			(PDFColor r: 0 g: 200 b: 45).
+		(doc styleSheet > #apocalypseClock)
+			fillColor: (PDFColor r: 244 g: 221 b: 25);
+			thickness: 2 mm;
+			roundCap: true.
+		(doc styleSheet > #apocalypseClock > #minuteHand)
+			drawColor: (PDFColor r: 240 g: 6 b: 7);
+			thickness: 1 mm.
+		doc exportTo: s ]
 ]
 
 { #category : #tool }
-PDFClockElement class >> streamNamed: aName [
-	| file |
-	file := aName asFileReference.
-	file ensureDelete.
-	self flag: #todo.	"The next expression is a hack to correct a Pharo 6/7 compatibility.
-	We need a binary write stream to print on but the way to get one changed between Pharo 6 and 7. To improve the code we could add a Pharo^ compatibility package that would add #binaryWriteStream to Pharo 6, but I have not time for now, I just want to make demos work.
-	"
-	^ SystemVersion current major < 7
-		ifTrue: [ file writeStream
-				binary;
-				yourself ]
-		ifFalse: [ file binaryWriteStream ]
+PDFClockElement class >> streamNamed: aName do: aBlock [
+
+	^ PDFDemos streamNamed: aName do: aBlock
 ]
 
 { #category : #style }

--- a/src/Artefact-Examples/PDFDemos.class.st
+++ b/src/Artefact-Examples/PDFDemos.class.st
@@ -20,7 +20,9 @@ PDFDemos class >> CDTemplateTest [
 	"PDFDemos CDTemplateTest"
 
 	<script>
-	self new CDTemplateTest: (self streamNamed: 'CDTemplateTest.pdf')
+	self
+		streamNamed: 'CDTemplateTest.pdf'
+		do: [ :s | self new CDTemplateTest: s ]
 ]
 
 { #category : #templates }
@@ -28,7 +30,9 @@ PDFDemos class >> DVDTemplateTest [
 	"PDFDemos DVDTemplateTest"
 
 	<script>
-	self new DVDTemplateTest: (self streamNamed: 'DVDTemplateTest.pdf')
+	self
+		streamNamed: 'DVDTemplateTest.pdf'
+		do: [ :s | self new DVDTemplateTest: s ]
 ]
 
 { #category : #text }
@@ -36,7 +40,9 @@ PDFDemos class >> alignmentsTest [
 	"PDFDemos alignmentsTest"
 
 	<script>
-	self new alignmentsTest: (self streamNamed: 'alignmentsTest.pdf')
+	self
+		streamNamed: 'alignmentsTest.pdf'
+		do: [ :s | self new alignmentsTest: s ]
 ]
 
 { #category : #composite }
@@ -44,7 +50,9 @@ PDFDemos class >> arrowTest [
 	"PDFDemos arrowTest"
 
 	<script>
-	self new arrowTest: (self streamNamed: 'arrowTest.pdf')
+	self
+		streamNamed: 'arrowTest.pdf'
+		do: [ :s | self new arrowTest: s ]
 ]
 
 { #category : #draw }
@@ -52,7 +60,9 @@ PDFDemos class >> bezierTest [
 	"PDFDemos bezierTest"
 
 	<script>
-	self new bezierTest: (self streamNamed: 'bezierTest.pdf')
+	self
+		streamNamed: 'bezierTest.pdf'
+		do: [ :s | self new bezierTest: s ]
 ]
 
 { #category : #experimental }
@@ -60,7 +70,9 @@ PDFDemos class >> brochureTest [
 	"PDFDemos brochureTest"
 
 	<script>
-	self new brochure: (self streamNamed: 'brochure.pdf')
+	self
+		streamNamed: 'brochureTest.pdf'
+		do: [ :s | self new brochureTest: s ]
 ]
 
 { #category : #draw }
@@ -68,7 +80,9 @@ PDFDemos class >> capLineTest [
 	"PDFDemos capLineTest"
 
 	<script>
-	self new capLineTest: (self streamNamed: 'capLineTest.pdf')
+	self
+		streamNamed: 'capLineTest.pdf'
+		do: [ :s | self new capLineTest: s ]
 ]
 
 { #category : #composite }
@@ -76,7 +90,9 @@ PDFDemos class >> cellTest [
 	"PDFDemos cellTest"
 
 	<script>
-	self new cellTest: (self streamNamed: 'cellTest.pdf')
+	self
+		streamNamed: 'cellTest.pdf'
+		do: [ :s | self new cellTest: s ]
 ]
 
 { #category : #draw }
@@ -84,7 +100,9 @@ PDFDemos class >> circlesTest [
 	"PDFDemos circlesTest"
 
 	<script>
-	self new circlesTest: (self streamNamed: 'circlesTest.pdf')
+	self
+		streamNamed: 'circlesTest.pdf'
+		do: [ :s | self new circlesTest: s ]
 ]
 
 { #category : #color }
@@ -92,7 +110,9 @@ PDFDemos class >> colorTest [
 	"PDFDemos colorTest"
 
 	<script>
-	self new colorTest: (self streamNamed: 'colorTest.pdf')
+	self
+		streamNamed: 'colorTest.pdf'
+		do: [ :s | self new colorTest: s ]
 ]
 
 { #category : #composite }
@@ -100,7 +120,9 @@ PDFDemos class >> datatableTest [
 	"PDFDemos datatableTest"
 
 	<script>
-	self new datatableTest: (self streamNamed: 'datatableTest.pdf')
+	self
+		streamNamed: 'datatableTest.pdf'
+		do: [ :s | self new datatableTest: s ]
 ]
 
 { #category : #composite }
@@ -108,7 +130,9 @@ PDFDemos class >> datatableWithCaptionsTest [
 	"PDFDemos datatableWithCaptionsTest"
 
 	<script>
-	self new datatableWithCaptionsTest: (self streamNamed: 'datatableWithCaptionsTest.pdf')
+	self
+		streamNamed: 'datatableWithCaptionsTest.pdf'
+		do: [ :s | self new datatableWithCaptionsTest: s ]
 ]
 
 { #category : #tool }
@@ -122,7 +146,9 @@ PDFDemos class >> documentDisplayLayoutTest [
 	"PDFDemos documentDisplayLayoutTest"
 
 	<script>
-	self new documentDisplayLayoutTest: (self streamNamed: 'documentDisplayLayoutTest.pdf')
+	self
+		streamNamed: 'documentDisplayLayoutTest.pdf'
+		do: [ :s | self new documentDisplayLayoutTest: s ]
 ]
 
 { #category : #'display setup' }
@@ -130,7 +156,9 @@ PDFDemos class >> documentDisplayModeTest [
 	"PDFDemos documentDisplayModeTest"
 
 	<script>
-	self new documentDisplayModeTest: (self streamNamed: 'documentDisplayModeTest.pdf')
+	self
+		streamNamed: 'documentDisplayModeTest.pdf'
+		do: [ :s | self new documentDisplayModeTest: s ]
 ]
 
 { #category : #'display setup' }
@@ -138,7 +166,9 @@ PDFDemos class >> documentZoomTest [
 	"PDFDemos documentZoomTest"
 
 	<script>
-	self new documentZoomTest: (self streamNamed: 'documentZoomTest.pdf')
+	self
+		streamNamed: 'documentZoomTest.pdf'
+		do: [ :s | self new documentZoomTest: s ]
 ]
 
 { #category : #color }
@@ -146,7 +176,9 @@ PDFDemos class >> drawStyleSheetTest [
 	"PDFDemos drawStyleSheetTest"
 
 	<script>
-	self new drawStyleSheetTest: (self streamNamed: 'drawStyleSheetTest.pdf')
+	self
+		streamNamed: 'drawStyleSheetTest.pdf'
+		do: [ :s | self new drawStyleSheetTest: s ]
 ]
 
 { #category : #draw }
@@ -154,7 +186,9 @@ PDFDemos class >> ellipsesTest [
 	"PDFDemos ellipsesTest"
 
 	<script>
-	self new ellipsesTest: (self streamNamed: 'ellipsesTest.pdf')
+	self
+		streamNamed: 'ellipsesTest.pdf'
+		do: [ :s | self new ellipsesTest: s ]
 ]
 
 { #category : #text }
@@ -162,7 +196,9 @@ PDFDemos class >> euroTest [
 	"PDFDemos euroTest"
 
 	<script>
-	self new euroTest: (self streamNamed: 'euroTest.pdf')
+	self
+		streamNamed: 'euroTest.pdf'
+		do: [ :s | self new euroTest: s ]
 ]
 
 { #category : #color }
@@ -170,7 +206,9 @@ PDFDemos class >> greyLevelTest [
 	"PDFDemos greyLevelTest"
 
 	<script>
-	self new greyLevelTest: (self streamNamed: 'greyLevelTest.pdf')
+	self
+		streamNamed: 'greyLevelTest.pdf'
+		do: [ :s | self new greyLevelTest: s ]
 ]
 
 { #category : #layout }
@@ -178,23 +216,29 @@ PDFDemos class >> horizontalLayoutTest [
 	"PDFDemos horizontalLayoutTest"
 
 	<script>
-	self new horizontalLayoutTest: (self streamNamed: 'horizontalLayoutTest.pdf')
+	self
+		streamNamed: 'horizontalLayoutTest.pdf'
+		do: [ :s | self new horizontalLayoutTest: s ]
 ]
 
 { #category : #image }
 PDFDemos class >> imageJPGTest [
-	"PDFDemos imageJPG"
+	"PDFDemos imageJPGTest"
 
 	<script>
-	self new imageJPG: (self streamNamed: 'imageJPG.pdf')
+	self
+		streamNamed: 'imageJPGTest.pdf'
+		do: [ :s | self new imageJPGTest: s ]
 ]
 
 { #category : #image }
 PDFDemos class >> imagePNGTest [
-	"PDFDemos imagePNG"
+	"PDFDemos imagePNGTest"
 
 	<script>
-	self new imagePNG: (self streamNamed: 'imagePNG.pdf')
+	self
+		streamNamed: 'imagePNGTest.pdf'
+		do: [ :s | self new imagePNGTest: s ]
 ]
 
 { #category : #document }
@@ -202,7 +246,9 @@ PDFDemos class >> infosTest [
 	"PDFDemos infosTest"
 
 	<script>
-	self new infosTest: (self streamNamed: 'infosTest.pdf')
+	self
+		streamNamed: 'infosTest.pdf'
+		do: [ :s | self new infosTest: s ]
 ]
 
 { #category : #draw }
@@ -210,7 +256,9 @@ PDFDemos class >> lineTest [
 	"PDFDemos lineTest"
 
 	<script>
-	self new lineTest: (self streamNamed: 'lineTest.pdf')
+	self
+		streamNamed: 'lineTest.pdf'
+		do: [ :s | self new lineTest: s ]
 ]
 
 { #category : #color }
@@ -218,7 +266,9 @@ PDFDemos class >> mosaiqueTest [
 	"PDFDemos mosaiqueTest"
 
 	<script>
-	self new mosaiqueTest: (self streamNamed: 'mosaiqueTest.pdf')
+	self
+		streamNamed: 'mosaiqueTest.pdf'
+		do: [ :s | self new mosaiqueTest: s ]
 ]
 
 { #category : #document }
@@ -226,7 +276,9 @@ PDFDemos class >> multiOrientationsTest [
 	"PDFDemos multiOrientationsTest"
 
 	<script>
-	self new multiOrientationsTest: (self streamNamed: 'multiOrientationsTest.pdf')
+	self
+		streamNamed: 'multiOrientationsTest.pdf'
+		do: [ :s | self new multiOrientationsTest: s ]
 ]
 
 { #category : #style }
@@ -234,7 +286,9 @@ PDFDemos class >> multiStyleArrowsTest [
 	"PDFDemos multiStyleArrowsTest"
 
 	<script>
-	self new multiStyleArrowsTest: (self streamNamed: 'multiStyleArrowsTest.pdf')
+	self
+		streamNamed: 'multiStyleArrowsTest.pdf'
+		do: [ :s | self new multiStyleArrowsTest: s ]
 ]
 
 { #category : #cool }
@@ -242,7 +296,9 @@ PDFDemos class >> oneLineTest [
 	"PDFDemos oneLineTest"
 
 	<script>
-	self new oneLineTest: (self streamNamed: 'oneLineTest.pdf')
+	self
+		streamNamed: 'oneLineTest.pdf'
+		do: [ :s | self new oneLineTest: s ]
 ]
 
 { #category : #composite }
@@ -250,7 +306,9 @@ PDFDemos class >> paragraphTest [
 	"PDFDemos paragraphTest"
 
 	<script>
-	self new paragraphTest: (self streamNamed: 'paragraphTest.pdf')
+	self
+		streamNamed: 'paragraphTest.pdf'
+		do: [ :s | self new paragraphTest: s ]
 ]
 
 { #category : #composite }
@@ -258,7 +316,9 @@ PDFDemos class >> paragraphWithSpacingTest [
 	"PDFDemos paragraphWithSpacingTest"
 
 	<script>
-	self new paragraphWithSpacingTest: (self streamNamed: 'paragraphWithSpacingTest.pdf')
+	self
+		streamNamed: 'paragraphWithSpacingTest.pdf'
+		do: [ :s | self new paragraphWithSpacingTest: s ]
 ]
 
 { #category : #draw }
@@ -266,7 +326,9 @@ PDFDemos class >> polygonsTest [
 	"PDFDemos polygonsTest"
 
 	<script>
-	self new polygonsTest: (self streamNamed: 'polygonsTest.pdf')
+	self
+		streamNamed: 'polygonsTest.pdf'
+		do: [ :s | self new polygonsTest: s ]
 ]
 
 { #category : #draw }
@@ -274,7 +336,9 @@ PDFDemos class >> rectsTest [
 	"PDFDemos rectsTest"
 
 	<script>
-	self new rectsTest: (self streamNamed: 'rectsTest.pdf')
+	self
+		streamNamed: 'rectsTest.pdf'
+		do: [ :s | self new rectsTest: s ]
 ]
 
 { #category : #experimental }
@@ -282,7 +346,9 @@ PDFDemos class >> rotationTest [
 	"PDFDemos rotationTest"
 
 	<script>
-	self new rotationTest: (self streamNamed: 'rotation.pdf')
+	self
+		streamNamed: 'rotationTest.pdf'
+		do: [ :s | self new rotationTest: s ]
 ]
 
 { #category : #runAllDemos }
@@ -294,19 +360,14 @@ PDFDemos class >> runAllDemos [
 ]
 
 { #category : #tool }
-PDFDemos class >> streamNamed: aName [
+PDFDemos class >> streamNamed: aName do: aBlock [
+
 	| file |
 	file := (self demoPath , aName) asFileReference.
 	file parent ensureCreateDirectory.
 	file ensureDelete.
-	self flag: #todo.	"The next expression is a hack to correct a Pharo 6/7 compatibility.
-	We need a binary write stream to print on but the way to get one changed between Pharo 6 and 7. To improve the code we could add a Pharo^ compatibility package that would add #binaryWriteStream to Pharo 6, but I have not time for now, I just want to make demos work.
-	"
-	^ SystemVersion current major < 7
-		ifTrue: [ file writeStream
-				binary;
-				yourself ]
-		ifFalse: [ file binaryWriteStream ]
+
+	^ file binaryWriteStreamDo: aBlock
 ]
 
 { #category : #text }
@@ -314,7 +375,9 @@ PDFDemos class >> textTest [
 	"PDFDemos textTest"
 
 	<script>
-	self new textTest: (self streamNamed: 'textTest.pdf')
+	self
+		streamNamed: 'textTest.pdf'
+		do: [ :s | self new textTest: s ]
 ]
 
 { #category : #draw }
@@ -322,7 +385,9 @@ PDFDemos class >> thicknessTest [
 	"PDFDemos thicknessTest"
 
 	<script>
-	self new thicknessTest: (self streamNamed: 'thicknessTest.pdf')
+	self
+		streamNamed: 'thicknessTest.pdf'
+		do: [ :s | self new thicknessTest: s ]
 ]
 
 { #category : #draw }
@@ -330,7 +395,9 @@ PDFDemos class >> twoColoredRectsOpacityTest [
 	"PDFDemos twoColoredRectsOpacityTest"
 
 	<script>
-	self new twoColoredRectsOpacityTest: (self streamNamed: 'twoColoredRectsOpacityTest.pdf')
+	self
+		streamNamed: 'twoColoredRectsOpacityTest.pdf'
+		do: [ :s | self new twoColoredRectsOpacityTest: s ]
 ]
 
 { #category : #draw }
@@ -338,7 +405,9 @@ PDFDemos class >> twoColoredRectsTest [
 	"PDFDemos twoColoredRectsTest"
 
 	<script>
-	self new twoColoredRectsTest: (self streamNamed: 'twoColoredRectsTest.pdf')
+	self
+		streamNamed: 'twoColoredRectsTest.pdf'
+		do: [ :s | self new twoColoredRectsTest: s ]
 ]
 
 { #category : #layout }
@@ -346,7 +415,9 @@ PDFDemos class >> verticalLayoutTest [
 	"PDFDemos verticalLayoutTest"
 
 	<script>
-	self new verticalLayoutTest: (self streamNamed: 'verticalLayoutTest.pdf')
+	self
+		streamNamed: 'verticalLayoutTest.pdf'
+		do: [ :s | self new verticalLayoutTest: s ]
 ]
 
 { #category : #misc }
@@ -354,7 +425,9 @@ PDFDemos class >> widthTest [
 	"PDFDemos widthTest"
 
 	<script>
-	self new widthTest: (self streamNamed: 'widthTest.pdf')
+	self
+		streamNamed: 'widthTest.pdf'
+		do: [ :s | self new widthTest: s ]
 ]
 
 { #category : #templates }
@@ -490,7 +563,7 @@ PDFDemos >> bezierTest: aStream [
 ]
 
 { #category : #experimental }
-PDFDemos >> brochure: aStream [
+PDFDemos >> brochureTest: aStream [
 	"Artefact use an JPG file"
 
 	| pdfdoc aPage titleFont subtitleFont titleColor layout quoteFont pharoLogo |
@@ -1104,14 +1177,14 @@ pdfdoc exportTo: aStream
 ]
 
 { #category : #image }
-PDFDemos >> imageJPG: aStream [
+PDFDemos >> imageJPGTest: aStream [
 	"How to use a JPEG file with artefact"
 
 	| pdfdoc aPage pharoByExampleLogo |
 	pdfdoc := PDFDocument new.
 	"Downloading JPEG file from internet with Zinc"
 	pharoByExampleLogo := (ZnClient new
-		url: 'https://gforge.inria.fr/frs/download.php/file/22781/pharocard.jpg';
+		url: 'https://files.pharo.org/media/pharocard.jpg';
 		get).
 	aPage := PDFPage new.
 	aPage add: (PDFJpegElement from: 5 mm@0mm dimension: 160mm@90mm fromStream: pharoByExampleLogo readStream).
@@ -1138,7 +1211,7 @@ pdfdoc exportTo: aStream
 ]
 
 { #category : #image }
-PDFDemos >> imagePNG: aStream [
+PDFDemos >> imagePNGTest: aStream [
 	"How to use a PNG file with artefact"
 
 	| pdfdoc aPage pharoLogo |

--- a/src/Artefact-Pharo6Compatibility/AbstractFileReference.extension.st
+++ b/src/Artefact-Pharo6Compatibility/AbstractFileReference.extension.st
@@ -1,0 +1,26 @@
+Extension { #name : #AbstractFileReference }
+
+{ #category : #'*Artefact-Pharo6Compatibility' }
+AbstractFileReference >> binaryWriteStream [
+	"Answer a binary write stream on the receiver"
+
+	^ self subclassResponsibility
+]
+
+{ #category : #'*Artefact-Pharo6Compatibility' }
+AbstractFileReference >> binaryWriteStreamDo: aBlock [
+	"Pass a binary write stream on the receiver to the supplied block, and ensure that the stream is closed after evaluation."
+
+	| stream |
+
+	stream := self binaryWriteStream.
+	^ [ aBlock value: stream ]
+		ensure: [ stream close ]
+]
+
+{ #category : #'*Artefact-Pharo6Compatibility' }
+AbstractFileReference >> binaryWriteStreamDo: doBlock ifPresent: presentBlock [
+	^ self isFile
+		ifTrue: [ presentBlock value ]
+		ifFalse: [ self binaryWriteStreamDo: doBlock ]
+]

--- a/src/Artefact-Pharo6Compatibility/FileLocator.extension.st
+++ b/src/Artefact-Pharo6Compatibility/FileLocator.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : #FileLocator }
+
+{ #category : #'*Artefact-Pharo6Compatibility' }
+FileLocator >> binaryWriteStream [
+	"Answer a binary write stream on the receiver"
+
+	^ self resolve binaryWriteStream
+]

--- a/src/Artefact-Pharo6Compatibility/FileReference.extension.st
+++ b/src/Artefact-Pharo6Compatibility/FileReference.extension.st
@@ -1,0 +1,9 @@
+Extension { #name : #FileReference }
+
+{ #category : #'*Artefact-Pharo6Compatibility' }
+FileReference >> binaryWriteStream [
+
+	^ (filesystem writeStreamOn: self path)
+		  binary;
+		  yourself
+]

--- a/src/Artefact-Pharo6Compatibility/package.st
+++ b/src/Artefact-Pharo6Compatibility/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Artefact-Pharo6Compatibility' }

--- a/src/BaselineOfArtefact/BaselineOfArtefact.class.st
+++ b/src/BaselineOfArtefact/BaselineOfArtefact.class.st
@@ -6,31 +6,48 @@ Class {
 
 { #category : #baselines }
 BaselineOfArtefact >> baseline: spec [
+
 	<baseline>
-	spec
-		for: #common
-		do: [
-			"Dependencies"
-			self
-				heimdall: spec;
-				materialDesignLite: spec;
-				stylesheet: spec;
-				units: spec.
+	spec for: #common do: [ 
+		"Dependencies"
+		self
+			heimdall: spec;
+			materialDesignLite: spec;
+			stylesheet: spec;
+			units: spec.
 
-			"Packages"
-			spec
-				package: 'Artefact-Core' with: [ spec requires: #('Units' 'Stylesheet') ];
-				package: 'Artefact-Examples' with: [ spec requires: #('Artefact-Core') ];
-				package: 'Artefact-Tests' with: [ spec requires: #('Artefact-Core' 'Artefact-Examples') ];
-				package: 'Artefact-Seaside' with: [ spec requires: #('default' 'Heimdall' 'MaterialDesignLite') ].
+		"Packages"
+		spec
+			package: 'Artefact-Core'
+			with: [ spec requires: #( 'Units' 'Stylesheet' ) ];
+			package: 'Artefact-Examples'
+			with: [ spec requires: #( 'Artefact-Core' ) ];
+			package: 'Artefact-Tests'
+			with: [ spec requires: #( 'Artefact-Core' 'Artefact-Examples' ) ];
+			package: 'Artefact-Seaside'
+			with: [
+				spec requires: #( 'default' 'Heimdall' 'MaterialDesignLite' ) ].
 
-			"Groups"
-			spec
-				group: 'default' with: #('core' 'tests' 'examples');
-				group: 'core' with: #('Artefact-Core');
-				group: 'tests' with: #('Artefact-Tests');
-				group: 'examples' with: #('Artefact-Examples');
-				group: 'seaside' with: #('Artefact-Seaside') ]
+		"Pharo 6- compatibility"
+		spec
+			for:
+				#( #'pharo1.x' #'pharo2.x' #'pharo3.x' #'pharo4.x' #'pharo5.x'
+				   #'pharo6.x' )
+			do: [
+				spec
+					package: 'Artefact-Pharo6Compatibility';
+					package: 'Artefact-Examples'
+					with: [
+						spec requires:
+								#( 'Artefact-Core' 'Artefact-Pharo6Compatibility' ) ] ].
+
+		"Groups"
+		spec
+			group: 'default' with: #( 'core' 'tests' 'examples' );
+			group: 'core' with: #( 'Artefact-Core' );
+			group: 'tests' with: #( 'Artefact-Tests' );
+			group: 'examples' with: #( 'Artefact-Examples' );
+			group: 'seaside' with: #( 'Artefact-Seaside' ) ]
 ]
 
 { #category : #dependencies }


### PR DESCRIPTION
Multiple PDFDemos fixes and improvements:

- PDFDemos created write streams without closing them, causing PDF files unable to open until Pharo is closed, fixed now by using `binaryWriteStreamDo:` instead of `binaryWriteStream`
- Moved Pharo 6- hotfixes into separate package that loads only for Pharo6-, that allowed simplifying PDFDemos code
- PDFClockElement now uses output code from PDFDemos instead of duplicating its code
- some PDFDemos instance-side methods now end with `Test` just like all other ones
- imageJPGTest - issue #13 - fixed by replacing not-working link to image with working one