### PR TITLE
Rename package Artefact-Tests into Artefact-Core-Tests

### DIFF
--- a/src/Artefact-Core-Tests/PDFBasicTest.class.st
+++ b/src/Artefact-Core-Tests/PDFBasicTest.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'element'
 	],
-	#category : #'Artefact-Tests-Base'
+	#category : #'Artefact-Core-Tests-Base'
 }
 
 { #category : #accessing }

--- a/src/Artefact-Core-Tests/PDFColorTest.class.st
+++ b/src/Artefact-Core-Tests/PDFColorTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #PDFColorTest,
 	#superclass : #TestCase,
-	#category : #'Artefact-Tests-Base'
+	#category : #'Artefact-Core-Tests-Base'
 }
 
 { #category : #tests }

--- a/src/Artefact-Core-Tests/PDFDataTypeTest.class.st
+++ b/src/Artefact-Core-Tests/PDFDataTypeTest.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'aStream'
 	],
-	#category : #'Artefact-Tests-DataTypes'
+	#category : #'Artefact-Core-Tests-DataTypes'
 }
 
 { #category : #utilities }

--- a/src/Artefact-Core-Tests/PDFDemosTest.class.st
+++ b/src/Artefact-Core-Tests/PDFDemosTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #PDFDemosTest,
 	#superclass : #TestCase,
-	#category : #'Artefact-Tests-Base'
+	#category : #'Artefact-Core-Tests-Base'
 }
 
 { #category : #tests }

--- a/src/Artefact-Core-Tests/PDFDummyBasic.class.st
+++ b/src/Artefact-Core-Tests/PDFDummyBasic.class.st
@@ -7,7 +7,7 @@ Instance Variables
 Class {
 	#name : #PDFDummyBasic,
 	#superclass : #PDFBasic,
-	#category : #'Artefact-Tests-Base'
+	#category : #'Artefact-Core-Tests-Base'
 }
 
 { #category : #style }

--- a/src/Artefact-Core-Tests/PDFDummyLayout.class.st
+++ b/src/Artefact-Core-Tests/PDFDummyLayout.class.st
@@ -7,7 +7,7 @@ Instance Variables
 Class {
 	#name : #PDFDummyLayout,
 	#superclass : #PDFLayout,
-	#category : #'Artefact-Tests-Elements'
+	#category : #'Artefact-Core-Tests-Elements'
 }
 
 { #category : #layouting }

--- a/src/Artefact-Core-Tests/PDFElementTest.class.st
+++ b/src/Artefact-Core-Tests/PDFElementTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #PDFElementTest,
 	#superclass : #TestCase,
-	#category : #'Artefact-Tests-Elements'
+	#category : #'Artefact-Core-Tests-Elements'
 }
 
 { #category : #'tests orientation' }

--- a/src/Artefact-Core-Tests/PDFFontTest.class.st
+++ b/src/Artefact-Core-Tests/PDFFontTest.class.st
@@ -5,7 +5,7 @@ Class {
 		'doc',
 		'page'
 	],
-	#category : #'Artefact-Tests-Base'
+	#category : #'Artefact-Core-Tests-Base'
 }
 
 { #category : #accessing }

--- a/src/Artefact-Core-Tests/PDFGeneratorTest.class.st
+++ b/src/Artefact-Core-Tests/PDFGeneratorTest.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'generator'
 	],
-	#category : #'Artefact-Tests-Generator'
+	#category : #'Artefact-Core-Tests-Generator'
 }
 
 { #category : #running }

--- a/src/Artefact-Core-Tests/PDFHorizontalLayoutTest.class.st
+++ b/src/Artefact-Core-Tests/PDFHorizontalLayoutTest.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'testLayout'
 	],
-	#category : #'Artefact-Tests-Layouts'
+	#category : #'Artefact-Core-Tests-Layouts'
 }
 
 { #category : #running }

--- a/src/Artefact-Core-Tests/PDFLayoutTest.class.st
+++ b/src/Artefact-Core-Tests/PDFLayoutTest.class.st
@@ -7,7 +7,7 @@ Class {
 		'page',
 		'document'
 	],
-	#category : #'Artefact-Tests-Elements'
+	#category : #'Artefact-Core-Tests-Elements'
 }
 
 { #category : #running }

--- a/src/Artefact-Core-Tests/PDFParagraphTest.class.st
+++ b/src/Artefact-Core-Tests/PDFParagraphTest.class.st
@@ -6,7 +6,7 @@ Class {
 		'page',
 		'paragraph'
 	],
-	#category : #'Artefact-Tests-Base'
+	#category : #'Artefact-Core-Tests-Base'
 }
 
 { #category : #accessing }

--- a/src/Artefact-Core-Tests/PDFStreamPrinterTest.class.st
+++ b/src/Artefact-Core-Tests/PDFStreamPrinterTest.class.st
@@ -5,7 +5,7 @@ Class {
 		'aStream',
 		'printer'
 	],
-	#category : #'Artefact-Tests-Generator'
+	#category : #'Artefact-Core-Tests-Generator'
 }
 
 { #category : #'tests compression' }

--- a/src/Artefact-Core-Tests/package.st
+++ b/src/Artefact-Core-Tests/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Artefact-Core-Tests' }

--- a/src/Artefact-Tests/package.st
+++ b/src/Artefact-Tests/package.st
@@ -1,1 +1,0 @@
-Package { #name : #'Artefact-Tests' }

--- a/src/BaselineOfArtefact/BaselineOfArtefact.class.st
+++ b/src/BaselineOfArtefact/BaselineOfArtefact.class.st
@@ -22,7 +22,7 @@ BaselineOfArtefact >> baseline: spec [
 			with: [ spec requires: #( 'Units' 'Stylesheet' ) ];
 			package: 'Artefact-Examples'
 			with: [ spec requires: #( 'Artefact-Core' ) ];
-			package: 'Artefact-Tests'
+			package: 'Artefact-Core-Tests'
 			with: [ spec requires: #( 'Artefact-Core' 'Artefact-Examples' ) ];
 			package: 'Artefact-Seaside'
 			with: [
@@ -42,12 +42,12 @@ BaselineOfArtefact >> baseline: spec [
 								#( 'Artefact-Core' 'Artefact-Pharo6Compatibility' ) ] ].
 
 		"Groups"
-		spec
-			group: 'default' with: #( 'core' 'tests' 'examples' );
-			group: 'core' with: #( 'Artefact-Core' );
-			group: 'tests' with: #( 'Artefact-Tests' );
+		spec			
+			group: 'core' with: #('Artefact-Core' );
+			group: 'tests' with: #( 'Artefact-Core-Tests' );
 			group: 'examples' with: #( 'Artefact-Examples' );
-			group: 'seaside' with: #( 'Artefact-Seaside' ) ]
+			group: 'seaside' with: #( 'Artefact-Seaside' );
+			group: 'default' with: #( 'core' 'tests' 'examples' ) ]
 ]
 
 { #category : #dependencies }


### PR DESCRIPTION
- Rename the package to comply with Pharo (and auto generation of test when jumping to test class)
- fix issue #16