### PR TITLE
PDFCompactDiscTemplate class>>#recommendedDocumentFormat not necessary

### DIFF
--- a/src/Artefact-Core/PDFTemplate.class.st
+++ b/src/Artefact-Core/PDFTemplate.class.st
@@ -18,11 +18,6 @@ Class {
 }
 
 { #category : #accessing }
-PDFTemplate class >> recommendedDocumentFormat [
-	self subclassResponsibility 
-]
-
-{ #category : #accessing }
 PDFTemplate >> dotted [
 	^dotted
 ]

--- a/src/Artefact-Examples/PDFCompactDiscTemplate.class.st
+++ b/src/Artefact-Examples/PDFCompactDiscTemplate.class.st
@@ -9,11 +9,6 @@ Class {
 }
 
 { #category : #accessing }
-PDFCompactDiscTemplate class >> recommendedDocumentFormat [
-	self subclassResponsibility 
-]
-
-{ #category : #accessing }
 PDFCompactDiscTemplate class >> recommendedPageFormat [
 	^(PDFA4Format new setLandscape)
 ]


### PR DESCRIPTION
Remove unncecessary method to fix #23